### PR TITLE
Rename `error_output` to `err_output`

### DIFF
--- a/config.go
+++ b/config.go
@@ -91,7 +91,7 @@ type Config struct {
 	// Note that this setting only affects internal errors; for sample code that
 	// sends error-level logs to a different location from info- and debug-level
 	// logs, see the package-level AdvancedConfiguration example.
-	ErrorOutput []string `mapstructure:"error_output"`
+	ErrorOutput []string `mapstructure:"err_output"`
 
 	// File logger options
 	FileLogger *FileLoggerConfig `mapstructure:"file_logger_options"`


### PR DESCRIPTION
# Reason for This PR

Fixed typo in config param https://github.com/search?q=org%3Aroadrunner-server%20err_output&type=code

## Description of Changes

Rename `error_output` to `err_output`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
