### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/format_handler.go
+++ b/format_handler.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -208,8 +209,8 @@ func (h *FormatHandler) clone() *FormatHandler {
 		format:      h.format,
 		timeLayout:  h.timeLayout,
 		lineEnding:  h.lineEnding,
-		preAttrs:    append([]slog.Attr(nil), h.preAttrs...),
-		groups:      append([]string(nil), h.groups...),
+		preAttrs:    slices.Clone(h.preAttrs),
+		groups:      slices.Clone(h.groups),
 		grpPfx:      h.grpPfx,
 		mu:          h.mu, // shared across clones
 		needsSource: h.needsSource,

--- a/handler.go
+++ b/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"strings"
 	"sync"
 )
 
@@ -34,17 +33,12 @@ func (h *RawHandler) Handle(_ context.Context, r slog.Record) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if _, err := io.WriteString(h.w, r.Message); err != nil {
-		return err
+	msg := r.Message
+	if len(msg) == 0 || msg[len(msg)-1] != '\n' {
+		msg += "\n"
 	}
-
-	if !strings.HasSuffix(r.Message, "\n") {
-		if _, err := io.WriteString(h.w, "\n"); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err := io.WriteString(h.w, msg)
+	return err
 }
 
 // WithAttrs returns the same handler — raw mode discards attributes.

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -149,7 +149,9 @@ go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhO
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
+go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
## Applied

| Lens | Location | Change |
|---|---|---|
| S | `handler.go:37` | Collapse two `io.WriteString`+`HasSuffix` calls into a single write; drop unused `strings` import |
| M | `format_handler.go:211` | Replace `append([]T(nil), ...)` idiom with `slices.Clone` for `preAttrs` and `groups` in `clone()` |

## Deps

`go get -u all && go mod tidy` in root and `tests/`; `go work sync`.

